### PR TITLE
fix a bug for changing password

### DIFF
--- a/src/main/java/com/raysmond/blog/services/UserService.java
+++ b/src/main/java/com/raysmond/blog/services/UserService.java
@@ -74,7 +74,8 @@ public class UserService implements UserDetailsService {
             return false;
 
         logger.info("" + passwordEncoder.matches(password, user.getPassword()));
-        if (!user.getPassword().equals(passwordEncoder.encode(password)))
+        boolean match = passwordEncoder.matches(password, user.getPassword());
+        if (!match)
             return false;
 
         user.setPassword(passwordEncoder.encode(newPassword));


### PR DESCRIPTION
`user.getPassword().equals(passwordEncoder.encode(password))` doesn't get a right boolean value to execute `user.setPassword(passwordEncoder.encode(newPassword))` correctly aiming to change password.
Though not knowing why, `passwordEncoder.matches` method works after several attempts to debug.