### PR TITLE
included messages.properties file in app config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,9 @@ spring:
         ehcache:
           config: classpath:ehcache.xml
 
+    #messages
+    spring.messages.basename: i18n/messages
+
 logging:
   level:
     org.springframework.web: ERROR


### PR DESCRIPTION
Need spring.messages.basename defined in app config so it can be accessed from the view templates.