### PR TITLE
Database should be called spring_blog_dev.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ And start MySQL and Redis first before running the application.
 apt-get install mysql-server
 service mysql start
 mysql -u root -p
->> create database spring_blog;
+>> create database spring_blog_dev;
 ```
 
 This is a Gradle project. Make sure Gradle is installed in your machine.


### PR DESCRIPTION
Command `./gradlew bootRun` failed because it was expecting a database called `spring_blog_dev` as opposed to `spring_blog` : updated README with correct `create database spring_blog_dev` command.